### PR TITLE
v2.1.3

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 build:
 	py -m build
 
-install: dist/multi_bible_search-2.1.2.tar.gz
-	pip install --force-reinstall ./dist/multi_bible_search-2.1.2.tar.gz
+install: dist/multi_bible_search-2.1.3.tar.gz
+	pip install --force-reinstall ./dist/multi_bible_search-2.1.3.tar.gz
 	copy venv\\Lib\\site-packages\\multi_bible_search\\*.pyd src\\multi_bible_search\\
 
 full: build install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multi_bible_search"
-version = "2.1.2"
+version = "2.1.3"
 authors = [
   { name="Samuel Howard" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 Set up the multi-bible-search extension.
 """
 import os
+import platform
 
 # pylint: disable=import-error
 from setuptools import setup, Extension
@@ -15,8 +16,10 @@ if os.name == "nt":
              "/arch:AVX2",  # For some reason, AVX2 is faster than AVX512 in my testing.
              "/fp:fast"  # Faster floating point ops, since precision is not needed for this
              ]
-else:
+elif "arm" not in platform.processor() and "Arm" not in platform.processor():
     flags = ["-O3", "-mavx2"]
+else:
+    flags = ["-O3"]
 
 setup(
     name='multi_bible_search',

--- a/src/multi_bible_search/bible_search_adapter.py
+++ b/src/multi_bible_search/bible_search_adapter.py
@@ -76,7 +76,11 @@ class BibleSearch:
         :return: None
         """
         base_path = os.path.dirname(os.path.abspath(__file__))
-        with bz2.open(f"{base_path}/data/{version}.json.pbz2", "rt", encoding='utf-8') as data_file:
+        with bz2.open(
+                f"{base_path}/data/{version}.json.pbz2",
+                "rt",
+                encoding='utf-8'
+        ) as data_file:
             self.__c_search.load(data_file.read(), version)
         if not preload:
             self.__loaded.add(version)
@@ -155,7 +159,12 @@ class BibleSearch:
         else:
             raise InvalidVersion(version)
 
-    def search(self, query: str, version: str = "KJV", max_results: int = sys.maxsize) -> List[str]:
+    def search(
+            self,
+            query: str,
+            version: str = "KJV",
+            max_results: int = sys.maxsize
+    ) -> List[str]:
         """
         Search for a passage in the Bible.
         :param query: The search query string.

--- a/src/multi_bible_search/multi_bible_search.c
+++ b/src/multi_bible_search/multi_bible_search.c
@@ -766,7 +766,7 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
             }
 
             // Copy previous token results
-            if (result_count && token_result_list_len > result_count) { //  && token_result_list ?
+            if (result_count && token_result_list_len > result_count) {
                 token_result_list = realloc(token_result_list, sizeof(result_pair) * token_result_list_len);
                 if (token_result_list == NULL) {
                     printf("Internal allocation error\n");
@@ -781,30 +781,25 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
                     return result_list;
                 }
             }
-            else {
-                continue;
-            }
 
             // Add results from all
             if (result_all != NULL) {
                 // Merge results from all
                 result_count = merge_results(token_result_list, result_count, result_all->value, result_all->length);
-                // result_count += result_all->length;
             }
 
             // Get results for version:
             if (result_version != NULL) {
                 // Merge results from this version
                 result_count = merge_results(token_result_list, result_count, result_version->value, result_version->length);
-                // result_count += result_version->length;
             }
 
             // If applicable, get results from extra index:
             if (result_combined != NULL) {
                 // Merge any results from the extra index
                 result_count = merge_results(token_result_list, result_count, result_combined->value, result_combined->length);
-                // result_count += result_combined->length;
             }
+            token_result_list_len = result_count;
         }
         // Free the dynamically allocated tokens
         for (int i = 0; i < len_tokens; i++)

--- a/src/multi_bible_search/multi_bible_search.c
+++ b/src/multi_bible_search/multi_bible_search.c
@@ -722,8 +722,10 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
     // Tokenize the query
     tokens = tokenize(query1, &num_tokens, &len_tokens);
 
-    // Pointer to the C list of results
-    long *token_result_list = NULL;
+    // Pointers to the C lists of results
+    result_pair *token_result_list = NULL;
+    long *token_result_list_longs = NULL;
+
     size_t result_count = 0,            // Current number of results
            token_result_list_len = 0;   // Allocated length of the result list
 
@@ -765,7 +767,7 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
 
             // Copy previous token results
             if (result_count && token_result_list_len > result_count) { //  && token_result_list ?
-                token_result_list = realloc(token_result_list, sizeof(long) * token_result_list_len);
+                token_result_list = realloc(token_result_list, sizeof(result_pair) * token_result_list_len);
                 if (token_result_list == NULL) {
                     printf("Internal allocation error\n");
                     return result_list;
@@ -773,7 +775,7 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
             }
             else if (token_result_list_len > 0 && token_result_list == NULL) {
                 // Allocate a temporary list of results
-                token_result_list = malloc(sizeof(long) * token_result_list_len);
+                token_result_list = malloc(sizeof(result_pair) * token_result_list_len);
                 if (token_result_list == NULL) {
                     printf("Internal allocation error\n");
                     return result_list;
@@ -786,22 +788,22 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
             // Add results from all
             if (result_all != NULL) {
                 // Merge results from all
-                merge(token_result_list, result_count, result_all->value, result_all->length);
-                result_count += result_all->length;
+                result_count = merge_results(token_result_list, result_count, result_all->value, result_all->length);
+                // result_count += result_all->length;
             }
 
             // Get results for version:
             if (result_version != NULL) {
                 // Merge results from this version
-                merge(token_result_list, result_count, result_version->value, result_version->length);
-                result_count += result_version->length;
+                result_count = merge_results(token_result_list, result_count, result_version->value, result_version->length);
+                // result_count += result_version->length;
             }
 
             // If applicable, get results from extra index:
             if (result_combined != NULL) {
                 // Merge any results from the extra index
-                merge(token_result_list, result_count, result_combined->value, result_combined->length);
-                result_count += result_combined->length;
+                result_count = merge_results(token_result_list, result_count, result_combined->value, result_combined->length);
+                // result_count += result_combined->length;
             }
         }
         // Free the dynamically allocated tokens
@@ -822,7 +824,11 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
     }
 
     // Rank the results, storing the length of the deduplicated portion of the array
-    result_count = rank(token_result_list, token_result_list_len, num_tokens, max_results);
+    token_result_list_longs = (long*) malloc(result_count * sizeof(long));
+    if (token_result_list_longs == NULL) {
+        goto token_free;
+    }
+    result_count = rank(token_result_list, result_count, num_tokens, max_results, token_result_list_longs);
 
     // By this point: result_count <= token_result_list_len
     if (max_results > result_count) {
@@ -831,7 +837,7 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
 
     for (size_t i = 0; i < max_results; i++) {
         // Translate the reference and add it to the Python list
-        str_ref = rtranslate(token_result_list[i]);
+        str_ref = rtranslate(token_result_list_longs[i]);
         // Make sure the result isn't None. Basically another double check of the Python side of things.
         if (str_ref != NULL) {
             // Add the resulting Python string to the list
@@ -842,9 +848,13 @@ PyObject *SearchObject_search(SearchObject *self, PyObject *args) {
         }
     }
 
-    // Free the dynamically allocated list 
+token_free:
+    // Free the dynamically allocated lists
     if (token_result_list != NULL) {
         free(token_result_list);
+    }
+    if (token_result_list_longs != NULL) {
+        free(token_result_list_longs);
     }
 
     // Give Python it's form of the results

--- a/src/multi_bible_search/parse_json.h
+++ b/src/multi_bible_search/parse_json.h
@@ -21,7 +21,7 @@ static inline size_t char_count(const char *str, const char character, int len) 
     for (int i = 0; i < len; i++) {
         if (str[i] == character) {
             count++;
-            // Each reference is at least 7 characters long, so jump by that much.
+            // Each reference is at least 4 characters long, so jump by that much.
             i += REF_MIN_LEN;
         }
     }

--- a/src/multi_bible_search/rank.h
+++ b/src/multi_bible_search/rank.h
@@ -44,46 +44,6 @@ static inline void countingSort(result_pair arr[], int n, long* destination, con
  * Merge two (individually sorted) lists together.
  * Assumes that the size of `dest` is `dest_len + src_len` 
  */
-static inline void merge(long* dest, size_t dest_len, long* src, size_t src_len) {
-    // Copy of the old destination array
-    long *old_dest = (long *) malloc(dest_len * sizeof(long));
-    if (!old_dest) {
-        printf("Memory allocation failure\n");
-        return;
-    }
-    memcpy_long(old_dest, dest, dest_len);
-
-    size_t i = 0,     // Iterator for `old_dest` array
-           j = 0;     // Iterator for `src` array
-
-    // Merge the two arrays low to high
-    while (i < dest_len && j < src_len) {
-        if (old_dest[i] < src[j]) {
-            *dest++ = old_dest[i];
-            i++;
-        }
-        else {
-            *dest++ = src[j];
-            j++;
-        }
-    }
-
-    // Copy what may remain in either array after merging
-    if (i < dest_len) {
-        memcpy_long(dest, &old_dest[i], (dest_len - i));
-    }
-    else if (j < src_len) {
-        memcpy_long(dest, &src[j], (src_len - j));
-    }
-
-    // Free the old destination array
-    free(old_dest);
-}
-
-/*
- * Merge two (individually sorted) lists together.
- * Assumes that the size of `dest` is `dest_len + src_len` 
- */
 static inline size_t merge_results(result_pair* dest, size_t dest_len, const long* src, size_t src_len) {
     // Copy of the old destination array
     result_pair *old = malloc(dest_len * sizeof(result_pair));
@@ -99,10 +59,8 @@ static inline size_t merge_results(result_pair* dest, size_t dest_len, const lon
     while (i < dest_len && j < src_len) {
         long val_old = old[i].element;
         long val_src = src[j];
-        if (val_old < val_src) {
-            dest[k++] = old[i++];
-        } 
-        else if (val_old == val_src) {
+         
+        if (val_old == val_src) {
             // Copy old entry, then add src occurrences
             dest[k] = old[i];
             // Count how many times src[j] repeats
@@ -115,6 +73,9 @@ static inline size_t merge_results(result_pair* dest, size_t dest_len, const lon
             k++;
             i++;
         } 
+        else if (val_old < val_src) {
+            dest[k++] = old[i++];
+        }
         else {
             // New element from src
             long current = val_src;

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -69,16 +69,20 @@ class TestPerf(unittest.TestCase):
             self.bible_search.search("Jesus wept")
         end = time.perf_counter()
         avg_time = (end - start) / count
+        print("Average case, no limit:")
         print(f"Total: {end - start:.4f}s\n"
               f"{avg_time:.8f}s per search average ({avg_time * 10 ** 6:.4f}μs)")
+        print("-" * 20)
         start = time.perf_counter()
         for _ in range(count):
             # Do some searching
             self.bible_search.search("comest goest")
         end = time.perf_counter()
         avg_time = (end - start) / count
+        print("Uncommon token pair:")
         print(f"Total: {end - start:.4f}s\n"
               f"{avg_time:.8f}s per search average ({avg_time * 10 ** 6:.4f}μs)")
+        print("-" * 20)
 
     def test_perf_max_results(self):
         """
@@ -92,16 +96,20 @@ class TestPerf(unittest.TestCase):
             self.bible_search.search("Jesus wept", max_results=100)
         end = time.perf_counter()
         avg_time = (end - start) / count
+        print("Common case, limit of 100 results")
         print(f"Total: {end - start:.4f}s\n"
               f"{avg_time:.8f}s per search average ({avg_time * 10 ** 6:.4f}μs)")
+        print("-" * 20)
         start = time.perf_counter()
         for _ in range(count):
             # Do some searching
             self.bible_search.search("comest goest", max_results=100)
         end = time.perf_counter()
         avg_time = (end - start) / count
+        print("Uncommon token pair, limit of 100 results:")
         print(f"Total: {end - start:.4f}s\n"
               f"{avg_time:.8f}s per search average ({avg_time * 10 ** 6:.4f}μs)")
+        print("-" * 20)
 
     def test_perf_long_query(self):
         """
@@ -132,6 +140,7 @@ class TestPerf(unittest.TestCase):
         avg_time = (end - start) / count
         print(f"Excessively long query total: {end - start:.4f}s\n"
               f"{avg_time:.8f}s per search average")
+        print("-" * 20)
 
         start = time.perf_counter()
         for _ in range(count):
@@ -149,6 +158,7 @@ class TestPerf(unittest.TestCase):
         avg_time = (end - start) / count
         print(f"Longest reasonable query total: {end - start:.4f}s\n"
               f"{avg_time:.8f}s per search average")
+        print("-" * 20)
 
     def test_profile(self):
         """
@@ -196,8 +206,10 @@ class TestPerf(unittest.TestCase):
                 )
                 time_accumulator += end - start
         avg_time = time_accumulator / count / len(keys)
+        print("Average retrieval time for 1 key:")
         print(f"Total: {time_accumulator:.4f}s\n"
               f"{avg_time:.8f}s per search average ({avg_time * 10 ** 6:.4f}μs)")
+        print("-" * 20)
 
 
 if __name__ == '__main__':

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,6 +31,7 @@ class TestSearch(unittest.TestCase):
             "hospitality, a lover of good men, sober, just, holy, temperate"
         )
         self.assertIn("Titus 1:8", query2)
+        self.assertIn("Titus 1:8", query2[:5], "Actual index: " + str(query2.index("Titus 1:8")))
         query3 = self.bible_search.search("elect")
         self.assertIn("Titus 1:1", query3)
         self.assertIn("Romans 8:33", query3)
@@ -52,15 +53,22 @@ class TestSearch(unittest.TestCase):
         query7 = self.bible_search.search(
             "And Israel dwelt in the land of Egypt, in the country of Goshen; and they "
             "had possessions therein, and grew, and multiplied exceedingly.")
-        self.assertIn("Genesis 47:27", query7[:3])
+        self.assertIn("Genesis 47:27", query7[:3], "Actual index: " + str(query7.index("Genesis 47:27")))
         query8 = self.bible_search.search("notawordinthebible")
         self.assertEqual(len(query8), 0)
         query9 = self.bible_search.search("Jesus wept", "ESV")
         self.assertGreater(len(query9), 0)
+        self.assertIn('John 11:35', query9[:5])
         query10 = self.bible_search.search(
             "And your feet shod with the preparation of the gospel of peace"
         )
+        self.assertIn("Ephesians 6:15", query10)
         self.assertEqual("Ephesians 6:15", query10[0])
+        query11 = self.bible_search.search(
+            "But a lover of hospitality, a lover of good men, sober, just, holy, temperate;"
+        )
+        self.assertIn("Titus 1:8", query11)
+        self.assertIn("Titus 1:8", query11[:5])
 
     def test_query_edge_cases(self):
         """

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -53,7 +53,10 @@ class TestSearch(unittest.TestCase):
         query7 = self.bible_search.search(
             "And Israel dwelt in the land of Egypt, in the country of Goshen; and they "
             "had possessions therein, and grew, and multiplied exceedingly.")
-        self.assertIn("Genesis 47:27", query7[:3], "Actual index: " + str(query7.index("Genesis 47:27")))
+        self.assertIn(
+            "Genesis 47:27", query7[:3],
+            "Actual index: " + str(query7.index("Genesis 47:27"))
+        )
         query8 = self.bible_search.search("notawordinthebible")
         self.assertEqual(len(query8), 0)
         query9 = self.bible_search.search("Jesus wept", "ESV")


### PR DESCRIPTION
### Improvements:

- Reworked how indices are stored before being ranked to improve worst-case performance

- Various other C code optimizations

#### Before:

- Total object size of 60.8 MiB

- Single-loaded version (KJV) object size of 7.2 MiB

- ~54μs per query (on my machine)

- ~1.1s per excessively long query (on my machine)

- Index size of 18.1 MiB

#### Now:

- Total object size of 60.8 MiB

- Single-loaded version (KJV) object size of 7.2 MiB

- ~48μs per query (on my machine)

- ~0.02411s per excessively long query (on my machine)

- Index size of 18.1 MiB